### PR TITLE
Add "fediverse:creator" meta tag to HTML head

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -66,6 +66,9 @@ summaryLength = 70
   # dateFormat = "Jan 2, 2006"
   # Which content sections appear on the homepage. Default: ["posts"]
   # mainSections = ["posts"]
+  # Value for "fediverse:creator" meta tag, for verified attribution in Mastodon and other federated socials.
+  # To enable attribution from this site on your Mastodon account, you must add this domain in your account settings.
+  # fediverseCreator = "@username@instance"
 
 # ---- UI Behavior ----
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,6 +5,7 @@
 
 {{ with .Description | default .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 {{ with .Params.author | default .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
+{{ with .Params.fediverseCreator | default .Site.Params.fediverseCreator }}<meta name="fediverse:creator" content="{{ . }}">{{ end }}
 <link rel="canonical" href="{{ .Permalink }}">
 {{ with .OutputFormats.Get "rss" }}
   {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}


### PR DESCRIPTION
Like the "author" meta tag, but with a fediverse handle instead of a name. Enables verified attribution in Mastodon and other federated social sites.