### PR TITLE
fix: Post list should use summary frontmatter by default

### DIFF
--- a/layouts/partials/post/list-item-default.html
+++ b/layouts/partials/post/list-item-default.html
@@ -20,7 +20,7 @@
   </header>
   {{ if $cfg.list.showExcerpt }}
     <div class="post-excerpt">
-      {{ .Plain | htmlUnescape | truncate 400 }}
+      {{ .Summary }}
     </div>
   {{ end }}
   {{ if or .Params.categories .Params.tags }}


### PR DESCRIPTION
Closes #7

Patch generated by `qwen3.6-35b-a3b via local API`.